### PR TITLE
Write own (very basic) implementation of StrEnum for Paths

### DIFF
--- a/home/pi/piScreen/piScreenUtils.py
+++ b/home/pi/piScreen/piScreenUtils.py
@@ -1,7 +1,12 @@
 #!/usr/bin/python3
 import logging, logging.handlers, __main__, os
+from enum import Enum
 
-class Paths():
+
+# TODO: Replace this line with `class Paths(StrEnum)' and add `from enum import StrEnum' to the
+# imports as soon as Python3.11 has been widely adopted by users of piScreen.
+# (StrEnum only is supported since Python3.11)
+class Paths(str, Enum):
 	RAMDISK = "/media/ramdisk/"
 	SOFTWARE_DIR = "/home/pi/piScreen/"
 	WWW_DIR = "/srv/piScreen/"


### PR DESCRIPTION
Deriving Paths from both str and Enum allows us to easily retrieve the value of an Enum member. We are now able to write `Paths.RAMDISK` instead of `Paths.RAMDISK.value` while maintaining the advantages of using an enum:

 - Hiding the value of all paths behind an easy to remember name of an enum member.
 - Immutable values, so they can't be accidentally changed in the middle of the piScreen source code
- Grouping these related constants into a single enum.

I will run this modified source code on my raspberry first to check for errors before converting the draft. (No more confusion like I caused with my previous commits, which had to be reverted in b8d8781 :wink: )