### PR TITLE
Update piScreen.service to support HDMI audio

### DIFF
--- a/etc/systemd/system/piScreen.service
+++ b/etc/systemd/system/piScreen.service
@@ -12,7 +12,7 @@ WorkingDirectory=/home/pi/piScreen
 TimeoutStopSec=10
 ExecStart=/home/pi/piScreen/piScreenCore.py &
 ExecStop=/home/pi/piScreen/piScreenCmd.py --stop-core
- 
+Environment="PULSE_RUNTIME_PATH=/run/user/1000/pulse/" 
 
 [Install]
 WantedBy=graphical.target


### PR DESCRIPTION
Added an environment variable to support HDMI audio via Pulse Audio Server in Raspberry Pi OS when running piScreen as a service.